### PR TITLE
modularize pip command and path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ These variables can be overriden either in container.yml during role inclusion, 
 - `bundle_build_cmd`: if you need to build a webpack or similar bundle, provide the command to run here
     - Note: any system dependencies required for this build command to run must be installed prior to this role.
 - `bundle_build_dir`: directory from which to run `bundle_build_cmd`, defaults to `manage_path`
+- `virtualenv_python_version`: Python executable with version, defaults to `python2.7`
+- `pip_command`: command used to execute pip, defaults to `pip`, another example is `pip3`
+- `pip_path`: absolute path to pip executable, defaults to `/usr/bin/{{ pip_command }}`
 
 ### Environment Variables
 #### The following environment variables must be defined by your container.yml django service in order to deploy this role.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 
 virtualenv_python_version: python2.7
+pip_command: pip
+pip_path: "/usr/bin/{{ pip_command }}"
 
 # top-level Django settings
 django_user: django

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,7 +33,7 @@
   pip:
     name: virtualenv
     state: latest
-    executable: /usr/bin/pip
+    executable: "{{ pip_path }}"
 
 - name: Clean yum cache
   command: yum clean all

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,6 @@
     mode: 0775
   with_items:
     - entrypoint.sh
-    - wait_on_postgres.py
     - manage_django.sh
 
 - name: Copy wait_on_postgres script

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,6 +37,14 @@
     - wait_on_postgres.py
     - manage_django.sh
 
+- name: Copy wait_on_postgres script
+  template:
+    src: "{{ role_path }}/templates/wait_on_postgres.py.j2"
+    dest: "/usr/bin/wait_on_postgres.py"
+    owner: root
+    group: root
+    mode: 0775
+
 - name: Copy any extra script templates
   template:
     src: "/src/{{ item }}"

--- a/tasks/virtualenv.yml
+++ b/tasks/virtualenv.yml
@@ -41,7 +41,7 @@
   remote_user: root
 
 - name: Install requirements with raw command
-  command: "env -i PATH=$PATH bash -c 'source {{ django_venv }}/bin/activate && pip install -r {{ django_root }}/requirements.txt'"
+  command: "env -i PATH=$PATH bash -c 'source {{ django_venv }}/bin/activate && {{ pip_command }} install -r {{ django_root }}/requirements.txt'"
 
 - name: Place postactivate script with secure permissions
   template:

--- a/templates/wait_on_postgres.py.j2
+++ b/templates/wait_on_postgres.py.j2
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env {{ virtualenv_python_version }}
 
 import sys
 import socket


### PR DESCRIPTION
Be able to set 'pip' command to 'pip3' and update path to that command.  Keeps defaults for python2.7 and regular 'pip' command.